### PR TITLE
Bump Qtum package to v0.0.13 (upstream v29.1)

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "qtum.avado.dnp.dappnode.eth",
-  "version": "0.0.12",
-  "upstream": "v27.1",
+  "version": "0.0.13",
+  "upstream": "v29.1",
   "title": "Qtum node",
   "description": "This is the Qtum Mainnet node. Qtum is an open sourced public blockchain platform, leveraging the security of UTXO while enabling EVM. Qtum is PoS based and boasts a Decentralized Governance Protocol (DGP) allowing specific blockchain settings to be modified by making use of smart contracts.",
   "avatar": "/ipfs/QmUJyDJqT5MMiDkLCuaiKGpQtjpGkTdLaN4ooboFQoouEB",
@@ -9,16 +9,9 @@
   "autoupdate": true,
   "image": {
     "restart": "always",
-    "environment": [
-      "EXTRA_OPTS"
-    ],
-    "ports": [
-      "3888:3888",
-      "3889:3889"
-    ],
-    "volumes": [
-      "data:/package/data"
-    ]
+    "environment": ["EXTRA_OPTS"],
+    "ports": ["3888:3888", "3889:3889"],
+    "volumes": ["data:/package/data"]
   },
   "author": "AVADO",
   "license": "(C)",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,25 @@
-version: '3.4'
+version: "3.4"
 services:
   qtum.avado.dnp.dappnode.eth:
-    image: 'qtum.avado.dnp.dappnode.eth:0.0.12'
+    image: "qtum.avado.dnp.dappnode.eth:0.0.13"
     build:
       context: ./build
       args:
-        - VERSION=v27.1
+        - VERSION=v29.1
     environment:
       - EXTRA_OPTS=
     volumes:
-      - 'data:/package/data'
+      - "data:/package/data"
     ports:
-      - '3888:3888'
-      - '3889:3889'
-      - '13888:13888'
-      - '13889:13889'
-      - '80:80'
-      - '443:443'
+      - "3888:3888"
+      - "3889:3889"
+      - "13888:13888"
+      - "13889:13889"
+      - "80:80"
+      - "443:443"
     logging:
       options:
         max-size: 10m
-        max-file: '3'
+        max-file: "3"
 volumes:
   data: {}


### PR DESCRIPTION
Update package and compose files for a new release: bump dappnode_package.json version 0.0.12 -> 0.0.13 and upstream v27.1 -> v29.1; update docker-compose image tag and build ARG accordingly. Also normalize JSON/YAML formatting (compact arrays and consistent quoting for environment, ports, volumes, and logging max-file) and add missing newline at EOF.